### PR TITLE
AI canvases: single root group + multi-select grouping

### DIFF
--- a/backend/design/create_design_file.ts
+++ b/backend/design/create_design_file.ts
@@ -1,6 +1,6 @@
 import { api } from "encore.dev/api";
 import { designDB } from "./db";
-import type { DesignFile, CanvasData } from "./types";
+import type { DesignFile, CanvasData, Layer } from "./types";
 
 export interface CreateDesignFileRequest {
   project_id: number;
@@ -12,14 +12,69 @@ export interface CreateDesignFileResponse {
   design_file: DesignFile;
 }
 
+function computeBBox(layers: Layer[]): { x: number; y: number; width: number; height: number } {
+  const xs = layers.map(l => l.x);
+  const ys = layers.map(l => l.y);
+  const rights = layers.map(l => l.x + l.width);
+  const bottoms = layers.map(l => l.y + l.height);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...rights);
+  const maxY = Math.max(...bottoms);
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+function normalizeInitialGrouping(canvas: CanvasData): CanvasData {
+  const layers = Array.isArray(canvas.layers) ? [...canvas.layers] as Layer[] : [];
+  if (layers.length === 0) return canvas;
+
+  const rootLayers = layers.filter(l => !l.parentId);
+  if (rootLayers.length === 0) return canvas;
+
+  if (rootLayers.length === 1 && rootLayers[0]?.type === 'group') {
+    return canvas;
+  }
+
+  const bbox = computeBBox(rootLayers);
+  const newGroupId = `group_${Date.now()}_${Math.random().toString(36).slice(2,9)}`;
+  const newGroup: Layer = {
+    id: newGroupId,
+    type: 'group',
+    name: 'AI Generated (Grouped)',
+    x: bbox.x,
+    y: bbox.y,
+    width: bbox.width,
+    height: bbox.height,
+    visible: true,
+    locked: false,
+    opacity: 1,
+    rotation: 0,
+    properties: { children: rootLayers.map(l => l.id) },
+  };
+
+  const updatedLayers: Layer[] = layers.map(l => {
+    if (!l.parentId) {
+      return { ...l, parentId: newGroupId, x: l.x - bbox.x, y: l.y - bbox.y };
+    }
+    return l;
+  });
+
+  // Insert new group as a root layer at index 0
+  updatedLayers.unshift(newGroup);
+
+  return { ...canvas, layers: updatedLayers };
+}
+
 // Creates a new design file within a project.
 export const createDesignFile = api<CreateDesignFileRequest, CreateDesignFileResponse>(
   { expose: true, method: "POST", path: "/design-files" },
   async (req) => {
-    const canvasData = req.canvas_data || {
+    const baseCanvas: CanvasData = req.canvas_data || {
       layers: [],
       viewport: { x: 0, y: 0, zoom: 1 }
     };
+
+    const canvasData = req.canvas_data ? normalizeInitialGrouping(baseCanvas) : baseCanvas;
 
     const designFile = await designDB.queryRow<DesignFile>`
       INSERT INTO design_files (project_id, name, canvas_data)

--- a/frontend/components/DesignEditor.tsx
+++ b/frontend/components/DesignEditor.tsx
@@ -24,8 +24,8 @@ import {
   ZoomOut,
   Grid,
   Sparkles,
-  Group,
-  Ungroup
+  Group as GroupIcon,
+  Ungroup as UngroupIcon
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -48,7 +48,7 @@ export function DesignEditor() {
   const { designId } = useParams<{ designId: string }>();
   const [designFile, setDesignFile] = useState<DesignFile | null>(null);
   const [canvasData, setCanvasData] = useState<CanvasData>({ layers: [], viewport: { x: 0, y: 0, zoom: 1 } });
-  const [selectedLayerId, setSelectedLayerId] = useState<string | null>(null);
+  const [selectedLayerIds, setSelectedLayerIds] = useState<string[]>([]);
   const [activeTool, setActiveTool] = useState<Tool>("select");
   const [collaborators, setCollaborators] = useState<CursorPosition[]>([]);
   const [loading, setLoading] = useState(true);
@@ -94,29 +94,38 @@ export function DesignEditor() {
         case 't': setActiveTool("text"); break;
         case 'delete':
         case 'backspace':
-          if (selectedLayerId) deleteLayer(selectedLayerId);
+          if (selectedLayerIds[0]) deleteLayer(selectedLayerIds[0]);
           break;
-        case 'escape': setSelectedLayerId(null); break;
+        case 'escape': setSelectedLayerIds([]); break;
         case 's':
           if (e.metaKey || e.ctrlKey) {
             e.preventDefault();
             saveDesignFile();
           }
           break;
-        case 'g':
+        case 'g': {
           if (e.metaKey || e.ctrlKey) {
             e.preventDefault();
-            if (selectedLayerId) {
-              const layer = canvasData.layers.find(l => l.id === selectedLayerId);
-              if (layer?.type === 'group') {
-                ungroupLayer(selectedLayerId);
+            const firstSelected = selectedLayerIds[0];
+            const layer = firstSelected ? canvasData.layers.find(l => l.id === firstSelected) : undefined;
+            if (e.shiftKey) {
+              if (firstSelected && layer?.type === 'group') {
+                ungroupLayer(firstSelected);
               } else {
-                // Placeholder for multi-select grouping
-                toast({ title: "Group", description: "Select multiple layers to group them." });
+                toast({ title: "Ungroup", description: "Select a single group to ungroup." });
+              }
+            } else {
+              if (firstSelected && layer?.type === 'group' && selectedLayerIds.length === 1) {
+                ungroupLayer(firstSelected);
+              } else if (selectedLayerIds.length >= 2) {
+                groupSelectedLayers(selectedLayerIds);
+              } else {
+                toast({ title: "Group", description: "Select multiple layers to group." });
               }
             }
           }
           break;
+        }
         case '?':
           if (e.shiftKey) setShowKeyboardShortcuts(true);
           break;
@@ -125,7 +134,7 @@ export function DesignEditor() {
 
     window.addEventListener('keydown', handleKeyboard);
     return () => window.removeEventListener('keydown', handleKeyboard);
-  }, [selectedLayerId, canvasData.layers]);
+  }, [selectedLayerIds, canvasData.layers]);
 
   const loadDesignFile = async () => {
     setLoading(true);
@@ -136,7 +145,7 @@ export function DesignEditor() {
       const response = await backend.design.getDesignFile({ id: parseInt(designId, 10) });
       setDesignFile(response);
       
-      let parsedCanvasData = response.canvas_data;
+      let parsedCanvasData = response.canvas_data as any;
       if (typeof parsedCanvasData === 'string') {
         try {
           parsedCanvasData = JSON.parse(parsedCanvasData);
@@ -218,7 +227,7 @@ export function DesignEditor() {
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
-    const rect = e.currentTarget.getBoundingClientRect();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
     sendCollaborationEvent({ type: "cursor", data: { x, y, color: "#6366F1" } });
@@ -239,9 +248,9 @@ export function DesignEditor() {
   };
 
   const addLayer = (layer: Omit<Layer, "id">) => {
-    const newLayer: Layer = { ...layer, id: `layer_${Date.now()}_${Math.random().toString(36).substr(2, 9)}` };
+    const newLayer: Layer = { ...layer, id: `layer_${Date.now()}_${Math.random().toString(36).substr(2, 9)}` } as Layer;
     setCanvasData(prev => ({ ...prev, layers: [...(prev.layers || []), newLayer] }));
-    setSelectedLayerId(newLayer.id);
+    setSelectedLayerIds([newLayer.id]);
     sendCollaborationEvent({ type: "layer_add", data: newLayer });
   };
 
@@ -268,14 +277,54 @@ export function DesignEditor() {
     });
 
     setCanvasData(prev => ({ ...prev, layers: updatedLayers }));
-    if (selectedLayerId === layerId) setSelectedLayerId(null);
+    if (selectedLayerIds.includes(layerId)) setSelectedLayerIds([]);
     sendCollaborationEvent({ type: "layer_delete", data: { layerId } });
   };
 
-  const duplicateLayer = (layerId: string) => {
-    const layer = (canvasData.layers || []).find(l => l.id === layerId);
-    if (!layer) return;
-    addLayer({ ...layer, name: `${layer.name} Copy`, x: layer.x + 10, y: layer.y + 10 });
+  const computeBBox = (layers: Layer[]) => {
+    const minX = Math.min(...layers.map(l => l.x));
+    const minY = Math.min(...layers.map(l => l.y));
+    const maxX = Math.max(...layers.map(l => l.x + l.width));
+    const maxY = Math.max(...layers.map(l => l.y + l.height));
+    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+  };
+
+  const groupSelectedLayers = (ids: string[]) => {
+    if ((ids?.length || 0) < 2) return;
+    const layers = canvasData.layers || [];
+    const selectedLayers = layers.filter(l => ids.includes(l.id) && !l.parentId);
+    if (selectedLayers.length < 2) return;
+
+    const bbox = computeBBox(selectedLayers);
+    const newGroupId = `group_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const newGroup: Layer = {
+      id: newGroupId,
+      type: 'group',
+      name: 'Group',
+      x: bbox.x,
+      y: bbox.y,
+      width: bbox.width,
+      height: bbox.height,
+      visible: true,
+      locked: false,
+      opacity: 1,
+      rotation: 0,
+      properties: { children: selectedLayers.map(l => l.id) },
+    } as Layer;
+
+    const updatedLayers: Layer[] = layers.map(l => {
+      if (ids.includes(l.id)) {
+        return { ...l, parentId: newGroupId, x: l.x - bbox.x, y: l.y - bbox.y };
+        }
+      return l;
+    });
+
+    updatedLayers.unshift(newGroup);
+
+    setCanvasData(prev => ({ ...prev, layers: updatedLayers }));
+    setSelectedLayerIds([newGroupId]);
+    toast({ title: "Grouped", description: `${selectedLayers.length} layers grouped.` });
+    sendCollaborationEvent({ type: "group", data: { groupId: newGroupId, children: newGroup.properties.children } });
   };
 
   const ungroupLayer = (groupId: string) => {
@@ -294,7 +343,7 @@ export function DesignEditor() {
       });
 
     setCanvasData(prev => ({ ...prev, layers: updatedLayers }));
-    setSelectedLayerId(null);
+    setSelectedLayerIds([]);
     toast({ title: "Ungrouped", description: "Layers have been ungrouped." });
     sendCollaborationEvent({ type: "ungroup", data: { groupId } });
   };
@@ -315,10 +364,13 @@ export function DesignEditor() {
     toast({ title: "AI Refinement Applied", description: description });
   };
 
-  const selectedLayer = selectedLayerId && canvasData.layers ? canvasData.layers.find(l => l.id === selectedLayerId) : null;
+  const selectedLayer = selectedLayerIds[0] && canvasData.layers ? canvasData.layers.find(l => l.id === selectedLayerIds[0]) : null;
 
   if (loading) return <div className="flex items-center justify-center h-screen">Loading...</div>;
   if (error || !designFile) return <div className="flex items-center justify-center h-screen">{error || "Design not found"}</div>;
+
+  const showUngroup = selectedLayer && selectedLayer.type === 'group' && selectedLayerIds.length === 1;
+  const canGroup = selectedLayerIds.length >= 2;
 
   return (
     <div className={`flex flex-col h-screen bg-neutral-50 dark:bg-neutral-950 ${isFullscreen ? 'fixed inset-0 z-50' : ''}`}>
@@ -338,10 +390,10 @@ export function DesignEditor() {
             <Button variant={activeTool === "circle" ? "secondary" : "ghost"} size="sm" onClick={() => setActiveTool("circle")} title="Circle (O)"><Circle className="h-4 w-4" /></Button>
             <Button variant={activeTool === "text" ? "secondary" : "ghost"} size="sm" onClick={() => setActiveTool("text")} title="Text (T)"><Type className="h-4 w-4" /></Button>
             <div className="h-6 w-px bg-neutral-200 dark:bg-neutral-700 mx-1"></div>
-            {selectedLayer?.type === "group" ? (
-              <Button variant="ghost" size="sm" onClick={() => ungroupLayer(selectedLayer.id)} title="Ungroup (Cmd+Shift+G)"><Ungroup className="h-4 w-4" /></Button>
+            {showUngroup ? (
+              <Button variant="ghost" size="sm" onClick={() => ungroupLayer(selectedLayer!.id)} title="Ungroup (Cmd+Shift+G)"><UngroupIcon className="h-4 w-4" /></Button>
             ) : (
-              <Button variant="ghost" size="sm" onClick={() => toast({ title: "Group", description: "Multi-select not yet implemented." })} title="Group (Cmd+G)"><Group className="h-4 w-4" /></Button>
+              <Button variant={canGroup ? "ghost" : "ghost"} size="sm" onClick={() => canGroup ? groupSelectedLayers(selectedLayerIds) : toast({ title: "Group", description: "Select multiple layers to group." })} title={canGroup ? "Group (Cmd+G)" : "Select multiple layers to group"} disabled={!canGroup}><GroupIcon className="h-4 w-4" /></Button>
             )}
             <div className="h-6 w-px bg-neutral-200 dark:bg-neutral-700 mx-1"></div>
             <Button variant="ghost" size="sm" onClick={() => setShowAIRefine(true)} title="AI Refine"><Sparkles className="h-4 w-4" /></Button>
@@ -372,17 +424,22 @@ export function DesignEditor() {
       <div className="flex flex-1 overflow-hidden">
         <div className="w-72 glass dark:glass-dark border-r overflow-y-auto">
           <div className="p-4 border-b"><h3 className="font-semibold flex items-center"><Layers className="h-4 w-4 mr-2" />Layers</h3></div>
-          <LayerPanel layers={canvasData.layers} selectedLayerId={selectedLayerId} onLayerSelect={setSelectedLayerId} onLayerUpdate={updateLayer} onLayerDelete={deleteLayer} onLayerDuplicate={duplicateLayer} onUngroupLayer={ungroupLayer} />
+          <LayerPanel layers={canvasData.layers} selectedLayerId={selectedLayerIds[0] || null} onLayerSelect={(id) => setSelectedLayerIds([id])} onLayerUpdate={updateLayer} onLayerDelete={deleteLayer} onLayerDuplicate={(id) => {
+            // keep behavior for first selection
+            const layer = canvasData.layers.find(l => l.id === id);
+            if (!layer) return;
+            addLayer({ ...layer, name: `${layer.name} Copy`, x: layer.x + 10, y: layer.y + 10 });
+          }} onUngroupLayer={ungroupLayer} />
         </div>
 
         <div className="flex-1 relative bg-neutral-100 dark:bg-neutral-900" onMouseMove={handleMouseMove}>
-          <Canvas canvasData={canvasData} selectedLayerId={selectedLayerId} activeTool={activeTool} onLayerSelect={setSelectedLayerId} onLayerAdd={addLayer} onLayerUpdate={updateLayer} onViewportChange={(viewport) => setCanvasData(prev => ({ ...prev, viewport }))} />
+          <Canvas canvasData={canvasData} selectedLayerIds={selectedLayerIds} activeTool={activeTool} onLayerSelect={setSelectedLayerIds} onLayerAdd={addLayer} onLayerUpdate={updateLayer} onViewportChange={(viewport) => setCanvasData(prev => ({ ...prev, viewport }))} />
           <CollaborationCursors cursors={collaborators} />
         </div>
 
         <div className="w-72 glass dark:glass-dark border-l overflow-y-auto">
           <div className="p-4 border-b"><h3 className="font-semibold flex items-center"><Settings className="h-4 w-4 mr-2" />Properties</h3></div>
-          <PropertiesPanel selectedLayer={selectedLayer} onLayerUpdate={(updates) => selectedLayer && updateLayer(selectedLayer.id, updates)} />
+          <PropertiesPanel selectedLayer={selectedLayer || null} onLayerUpdate={(updates) => selectedLayer && updateLayer(selectedLayer.id, updates)} />
         </div>
       </div>
 
@@ -391,7 +448,7 @@ export function DesignEditor() {
           <VersionHistory designFileId={parseInt(designId)} isOpen={showVersionHistory} onClose={() => setShowVersionHistory(false)} onVersionRestored={loadDesignFile} />
           <ExportDialog designFileId={parseInt(designId)} designFileName={designFile.name} isOpen={showExportDialog} onClose={() => setShowExportDialog(false)} />
           <CommentsPanel designFileId={parseInt(designId)} isOpen={showComments} onClose={() => setShowComments(false)} />
-          <AIRefineDialog isOpen={showAIRefine} onClose={() => setShowAIRefine(false)} onDesignRefined={handleAIRefine} currentCanvasData={canvasData} selectedLayerId={selectedLayerId} />
+          <AIRefineDialog isOpen={showAIRefine} onClose={() => setShowAIRefine(false)} onDesignRefined={handleAIRefine} currentCanvasData={canvasData} selectedLayerId={selectedLayerIds[0] || null} />
         </>
       )}
       <KeyboardShortcuts isOpen={showKeyboardShortcuts} onClose={() => setShowKeyboardShortcuts(false)} />


### PR DESCRIPTION
Normalize AI-created canvases to one root group at creation; add canvas multi-select with Group/Ungroup (toolbar + Cmd/Ctrl+G, Cmd/Ctrl+Shift+G). Keeps single-select flows and emits collaboration events.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/572169c0-84af-11f0-a94e-3eef481a796b/task/f3de4c8e-f6fc-40bf-a1a4-25416913a7f9))
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Normalize AI-generated canvases to a single root group at creation, and add true multi-select with Group/Ungroup (toolbar + Cmd/Ctrl+G, Cmd/Ctrl+Shift+G). This preserves layout and lets users select and drag multiple layers together.

- New Features
  - AI canvases auto-wrap into one root group; children are reparented and positioned relative to it.
  - Multi-select on canvas (Shift/Cmd/Ctrl-click) with group drag.
  - Group/Ungroup via toolbar and shortcuts; ungroup works when a single group is selected.
  - Emits collaboration events for group/ungroup.

- Refactors
  - Canvas selection is now an array (selectedLayerIds); drawing, hit-testing, and drag logic updated.
  - Keyboard and toolbar logic handle group vs ungroup; Layer panel keeps single-select behavior.

<!-- End of auto-generated description by cubic. -->

